### PR TITLE
Add Terraform and Ansible configurations for Moodle server deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+# Terraform and Ansible for Moodle Deployment on AWS
+
+This repository contains Terraform and Ansible configurations for deploying a Moodle server on AWS. Follow the instructions below to set up the environment and deploy Moodle.
+
+## Prerequisites
+
+1. **AWS Credentials**: Ensure you have AWS credentials configured on your machine. You can set them up using the AWS CLI:
+   ```sh
+   aws configure
+   ```
+
+2. **SSH Key Pair**: Create an SSH key pair to access the EC2 instance. You can create one using the AWS Management Console or the AWS CLI:
+   ```sh
+   aws ec2 create-key-pair --key-name MyKeyPair --query 'KeyMaterial' --output text > MyKeyPair.pem
+   chmod 400 MyKeyPair.pem
+   ```
+
+3. **Terraform**: Install Terraform on your machine. Follow the instructions on the [Terraform website](https://www.terraform.io/downloads.html).
+
+4. **Ansible**: Install Ansible on your machine. You can install it using pip:
+   ```sh
+   pip install ansible
+   ```
+
+## Terraform Configuration
+
+The `main.tf` file contains the Terraform configuration for deploying an EC2 instance on AWS.
+
+### Steps to Deploy
+
+1. Initialize Terraform:
+   ```sh
+   terraform init
+   ```
+
+2. Apply the Terraform configuration:
+   ```sh
+   terraform apply
+   ```
+
+3. Note the public IP address of the created EC2 instance from the Terraform output.
+
+## Ansible Playbook
+
+The `moodle_setup.yml` file contains the Ansible playbook for setting up the Moodle server on the EC2 instance.
+
+### Steps to Run the Playbook
+
+1. Update the `moodle_setup.yml` file with the correct path to your local Moodle files:
+   ```yaml
+   vars:
+     moodle_local_path: "/path/to/local/moodle"
+     moodle_remote_path: "/var/www/html/moodle"
+   ```
+
+2. Run the Ansible playbook:
+   ```sh
+   ansible-playbook -i <EC2_PUBLIC_IP>, -u ubuntu --private-key MyKeyPair.pem moodle_setup.yml
+   ```
+
+## Security Best Practices
+
+- **IAM Roles**: Use IAM roles for the EC2 instance to manage permissions securely.
+- **Security Groups**: Ensure the security group allows only necessary traffic (HTTP on port 80 and SSH on port 22).
+- **SSH Key Management**: Keep your SSH private key secure and do not share it.
+
+## Conclusion
+
+By following the above instructions, you can deploy a Moodle server on AWS using Terraform and Ansible. Ensure you follow security best practices to keep your environment secure.

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,44 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_security_group" "moodle_sg" {
+  name        = "moodle_sg"
+  description = "Allow HTTP and SSH traffic"
+  vpc_id      = "vpc-123456"
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "moodle_instance" {
+  ami           = "ami-0c55b159cbfafe1f0"
+  instance_type = "t2.micro"
+  security_groups = [aws_security_group.moodle_sg.name]
+
+  tags = {
+    Name = "MoodleServer"
+  }
+}
+
+output "instance_public_ip" {
+  value = aws_instance.moodle_instance.public_ip
+}

--- a/moodle_setup.yml
+++ b/moodle_setup.yml
@@ -1,0 +1,61 @@
+---
+- name: Setup Moodle Server
+  hosts: all
+  become: yes
+
+  vars:
+    moodle_local_path: "/path/to/local/moodle"
+    moodle_remote_path: "/var/www/html/moodle"
+
+  tasks:
+    - name: Update package repository
+      apt:
+        update_cache: yes
+
+    - name: Install Apache
+      apt:
+        name: apache2
+        state: present
+
+    - name: Install PHP 8.1
+      apt:
+        name: php8.1
+        state: present
+
+    - name: Install PHP MySQL extension
+      apt:
+        name: php8.1-mysql
+        state: present
+
+    - name: Enable PHP module for Apache
+      command: a2enmod php8.1
+
+    - name: Start Apache service
+      service:
+        name: apache2
+        state: started
+        enabled: yes
+
+    - name: Copy Moodle files to server
+      copy:
+        src: "{{ moodle_local_path }}"
+        dest: "{{ moodle_remote_path }}"
+        owner: www-data
+        group: www-data
+        mode: '0755'
+
+    - name: Configure Apache to serve Moodle on port 8050
+      template:
+        src: moodle.conf.j2
+        dest: /etc/apache2/sites-available/moodle.conf
+      notify: Restart Apache
+
+    - name: Enable Moodle site configuration
+      command: a2ensite moodle.conf
+      notify: Restart Apache
+
+  handlers:
+    - name: Restart Apache
+      service:
+        name: apache2
+        state: restarted


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a comprehensive `README.md` file with deployment instructions for setting up a Moodle server on AWS using Terraform and Ansible.
	- Added a Terraform configuration to create an EC2 instance with security group settings for HTTP and SSH access.
	- Implemented an Ansible playbook to automate the Moodle server setup, including installation of necessary packages and configuration of the web server.

- **Documentation**
	- Enhanced documentation to include security best practices and detailed steps for deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->